### PR TITLE
Fix a 404 issue with fbclid get argument

### DIFF
--- a/src/Hook/InitializeSystemHook.php
+++ b/src/Hook/InitializeSystemHook.php
@@ -15,6 +15,11 @@ class InitializeSystemHook
 {
     public function initializeSystem()
     {
+        // Catch Facebook token fbclid and redirect without him (trigger 404 errors)...
+        if (strpos(\Environment::get('request'), '?fbclid')) {
+            \Controller::redirect(strtok(\Environment::get('request'), '?'));
+        }
+        
         // If there is no request, add the browser language
         if ("" === \Environment::get('request')) {
             // check if the browser language is available


### PR DESCRIPTION
Since Octobre 2018, Facebook got the good idea to put a f*cking tracker in URL pasted in their system. 
With the way contao-i18nl10n works, it triggers a 404 since the GET argument messed up the way Contao handle requests.

By simply catch the token and redirect to the URL without it, it works fine.