### PR TITLE
Keep the absolute URL when passing an absolute URL in generateFrontendUrl Hook

### DIFF
--- a/src/Hook/GenerateFrontendUrlHook.php
+++ b/src/Hook/GenerateFrontendUrlHook.php
@@ -132,6 +132,14 @@ class GenerateFrontendUrlHook
             $strL10nUrl = $language."/";
         }
 
+        // Finally, if the basic url contains the domain, it means we want an absolute URL, so keep it this way
+        if (false !== strpos($strUrl, \Environment::get('base'))) {
+            $strL10nUrl = ($arrRow['rootUseSSL'] ? 'https://' : 'http://')
+                    . ($arrRow['domain'] ?: \Environment::get('host'))
+                    . '/'
+                    . $strL10nUrl;
+        }
+
         return $strL10nUrl;
     }
 }


### PR DESCRIPTION
Issue found when generating the sitemaps who requires absolute URLs.
The getSearchablePagesHook of contao-i18nl10n handle correctly the way pages from alternatives languages are generated in the sitemap but not the main language. 

So we add a test in generateFrontendUrl hook to check if the URL generated before the hook contains the domain, and keep it if it's the case.