### PR TITLE
Add a way to keep the auto item exactly how it is

### DIFF
--- a/src/Hook/GenerateFrontendUrlHook.php
+++ b/src/Hook/GenerateFrontendUrlHook.php
@@ -140,6 +140,14 @@ class GenerateFrontendUrlHook
                     . $strL10nUrl;
         }
 
+        // Add a way to keep the auto item exactly how it is
+        // Because when hook find a new page, he doesn't keep it and it send us into 404 pages
+        // It's a quickfix, harmless to existing codes, but works very well with i18nl10nUpdateLanguageSelectionItem hook
+        // You can add a hook to edit the $arrRow array and set $arrRow["keepAutoitem"] to true before return $arrRow
+        if ($arrRow["keepAutoitem"] && \Input::get('auto_item') && false == strpos($strL10nUrl, \Input::get('auto_item'))) {
+            $strL10nUrl = str_replace(\Config::get('urlSuffix'), "/".\Input::get('auto_item').\Config::get('urlSuffix'), $strL10nUrl);
+        }
+
         return $strL10nUrl;
     }
 }

--- a/src/Hook/InitializeSystemHook.php
+++ b/src/Hook/InitializeSystemHook.php
@@ -36,13 +36,13 @@ class InitializeSystemHook
                 throw new NoRootPageException();
             }
 
-            $languages = $arrLanguages[$_SERVER['HTTP_HOST']] ?: $arrLanguages['*'];
+            /*$languages = $arrLanguages[$_SERVER['HTTP_HOST']] ?: $arrLanguages['*'];
 
             if (in_array($userLanguage, $languages['languages'])) {
                 $strRedirect = $userLanguage."/";
             } else {
                 $strRedirect = $languages['default']."/";
-            }
+            }*/
 
             // @todo:   Replace with other logic as this does not work as intendet.
             //Controller::redirect($strRedirect);

--- a/src/Resources/contao/dca/tl_page_i18nl10n.php
+++ b/src/Resources/contao/dca/tl_page_i18nl10n.php
@@ -11,6 +11,7 @@
  * @license     LGPLv3 http://www.gnu.org/licenses/lgpl-3.0.html
  */
 
+use Contao\DataContainer;
 use Verstaerker\I18nl10nBundle\Classes\I18nl10n;
 
 // load language translations


### PR DESCRIPTION
Add a way to keep the auto item exactly how it is
Because when hook find a new page, he doesn't keep it and it send us into 404 pages
It's a quickfix, harmless to existing codes, but works very well with i18nl10nUpdateLanguageSelectionItem hook
You can add a hook to edit the $arrRow array and set $arrRow["keepAutoitem"] to true before return $arrRow

Exemple :
config.php
```php
$GLOBALS['TL_HOOKS']['i18nl10nUpdateLanguageSelectionItem'][] = array("WEM\Hooks", "keepLocationsAutoitem");
```

hook :
```php
/**
     * Adjusts the way Locations URLs are generated
     * (useful for i18nl10n plugin)
     *
     * @param Array $item | Item sent by module
     *
     * @return Array
     */
    public function keepLocationsAutoitem($item)
    {
        if (!\Input::get('auto_item')) {
            return $item;
        }

        $objCurrentItem = Location::findByIdOrAlias(\Input::get('auto_item'));

        if (!$objCurrentItem) {
            return $item;
        }

        $item["keepAutoitem"] = true;
        return $item;
    }
```

URL generated without the hook by the changelanguage module : 
en/location/location-a.html --> fr/location.html

with the keepAutoItem :
en/location/location-a.html --> fr/location/location-a.html